### PR TITLE
Allow set history in action in flow configuration

### DIFF
--- a/src/models/flow/flow.model.tsx
+++ b/src/models/flow/flow.model.tsx
@@ -406,7 +406,9 @@ export class Flow {
 
 				this.treatHistory(nextStepFnResult.stepName);
 
-				if (nextStepFnResult?.options?.clearHistory) {
+				if (nextStepFnResult?.options?.history) {
+					this.history = nextStepFnResult?.options?.history;
+				} else if (nextStepFnResult?.options?.clearHistory) {
 					this.clearHistory();
 				}
 

--- a/src/types/flow/flow.type.tsx
+++ b/src/types/flow/flow.type.tsx
@@ -23,6 +23,12 @@ export type TFlowActionOptions = {
 	 * Default: false
 	 */
 	clearHistory?: boolean;
+	/**
+	 * Set array of all steps saved in history. This action replace current steps in history by passed history.
+	 *
+	 * Default: null
+	 */
+	history?: Array<string>;
 };
 
 export interface TFlowManagerOptions {


### PR DESCRIPTION
```js
example1.step("screen1")({
  next: "screen2",
  recover: () => ({
    stepName: "screen3",
    options: { history: ["screen1", "screen2"] },
  }),
});
```